### PR TITLE
Allow testing with tox

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(libsudoku)
 
 include_directories(libsudoku/src)
 
+# https://pybind11.readthedocs.io/en/stable/compiling.html#building-with-cmake
 pybind11_add_module(py_libsudoku src/py_libsudoku.cpp)
 target_link_libraries(py_libsudoku PRIVATE libsudoku_objs)
 set_target_properties(py_libsudoku 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+# https://github.com/patrikhuber/eos/blob/master/MANIFEST.in
+recursive-include libsudoku *
+recursive-include pybind11 *
+# An alternative to including pybind11 here is to FetchContent https://stackoverflow.com/questions/47027741/smart-way-to-cmake-a-project-using-pybind11-by-externalproject-add

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ class CMakeBuild(build_ext):
                                                               self.distribution.get_version())
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
+        assert os.path.exists(os.path.join(ext.sourcedir, 'CMakeLists.txt')) # check sourcedir was installed
         subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
         subprocess.check_call(['cmake', '--build', '.'] + build_args, cwd=self.build_temp)
 
@@ -66,4 +67,6 @@ setup(
     ext_modules=[CMakeExtension('py_libsudoku')],
     cmdclass=dict(build_ext=CMakeBuild),
     zip_safe=False,
+    use_scm_version=True,
+    setup_requires=['setuptools_scm'],
 )

--- a/src/tests/test_board.py
+++ b/src/tests/test_board.py
@@ -3,3 +3,23 @@ import py_libsudoku
 
 def test_clear_board():
     clear_board = py_libsudoku.Board()
+    assert clear_board.isEmpty
+    assert clear_board.isValid
+    assert not clear_board.isComplete
+
+def test_one_to_nine():
+    one_to_nine = py_libsudoku.Board([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    assert not one_to_nine.isEmpty
+    assert one_to_nine.isValid
+    assert not one_to_nine.isComplete
+
+    one_to_nine_cpy = py_libsudoku.Board(one_to_nine)
+    assert one_to_nine_cpy == one_to_nine
+
+    assert one_to_nine_cpy.valueAt(line=1, column=0) == 0
+    result = one_to_nine_cpy.setValueAt(1, 0, 1)
+    assert result == py_libsudoku.SetValueResult.VALUE_INVALIDATES_BOARD
+    assert one_to_nine_cpy.valueAt(line=1, column=0) == 0
+
+    one_to_nine_cpy.clear()
+    assert one_to_nine_cpy != one_to_nine

--- a/src/tests/test_board.py
+++ b/src/tests/test_board.py
@@ -1,0 +1,5 @@
+import py_libsudoku
+
+
+def test_clear_board():
+    clear_board = py_libsudoku.Board()

--- a/src/tests/test_solver.py
+++ b/src/tests/test_solver.py
@@ -1,0 +1,20 @@
+import py_libsudoku
+
+
+def test_solve():
+    solvable_one_solution = py_libsudoku.Board(
+    [0, 0, 6, 0, 0, 8, 5, 0, 0,
+     0, 0, 0, 0, 7, 0, 6, 1, 3,
+     0, 0, 0, 0, 0, 0, 0, 0, 9,
+     0, 0, 0, 0, 9, 0, 0, 0, 1,
+     0, 0, 1, 0, 0, 0, 8, 0, 0,
+     4, 0, 0, 5, 3, 0, 0, 0, 0,
+     1, 0, 7, 0, 5, 3, 0, 0, 0,
+     0, 5, 0, 0, 6, 4, 0, 0, 0,
+     3, 0, 0, 1, 0, 0, 0, 6, 0]
+    )
+    solution = py_libsudoku.Board()
+    solver = py_libsudoku.Solver()
+    result = solver.solve(solvable_one_solution, solution)
+    if result == py_libsudoku.SolverResult.NO_ERROR:
+      assert solution.isComplete

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[testenv]
+deps =
+    pytest
+commands =
+    pytest --verbose --ignore pybind11
+


### PR DESCRIPTION
If you're interested, this sets up the package to run tests with tox.

This would allow setting up the package to run automated tests (on Travis, for example) for each update. That might be good to have if you're publishing on PyPI.